### PR TITLE
Use RWJS_API_URL

### DIFF
--- a/web/src/pages/StripeCartPage/StripeCartPage.js
+++ b/web/src/pages/StripeCartPage/StripeCartPage.js
@@ -62,26 +62,20 @@ const StripeCartPage = () => {
 
 export default StripeCartPage
 
-/**
- * This is a hack. There should be a better way.
- */
-const getApiUrl = () =>
-  window.RWJS_API_GRAPHQL_URL.split('/').slice(0, -1).join('/')
-
 const retrieveCheckoutSession = async (id) => {
-  const response = await window.fetch(
-    `${getApiUrl()}/retrieveCheckoutSession`,
+  const res = await window.fetch(
+    `${window.RWJS_API_URL}/retrieveCheckoutSession`,
     {
       method: 'POST',
       body: JSON.stringify({ id: id }),
     }
   )
-  return response.json()
+  return res.json()
 }
 
 const handleCheckoutSessionCreation = async (mode) => {
   const stripey = await loadStripe(process.env.STRIPE_PK)
-  const response = await fetch(`${getApiUrl()}/createCheckoutSession`, {
+  const response = await fetch(`${window.RWJS_API_URL}/createCheckoutSession`, {
     method: 'POST',
     body: JSON.stringify({ mode: mode }),
   })
@@ -99,7 +93,7 @@ const handleCheckoutSessionCreation = async (mode) => {
 // TODO: remove customer id after creating wway to save session info
 const handleCustomerPortalSessionCreation = async (customer) => {
   const response = await window.fetch(
-    `${getApiUrl()}/createCustomerPortalSession`,
+    `${window.RWJS_API_URL}/createCustomerPortalSession`,
     {
       method: 'POST',
       body: JSON.stringify({ customer: customer }),

--- a/web/src/pages/StripeCartPage/StripeCartPage.js
+++ b/web/src/pages/StripeCartPage/StripeCartPage.js
@@ -63,14 +63,14 @@ const StripeCartPage = () => {
 export default StripeCartPage
 
 const retrieveCheckoutSession = async (id) => {
-  const res = await window.fetch(
+  const response = await window.fetch(
     `${window.RWJS_API_URL}/retrieveCheckoutSession`,
     {
       method: 'POST',
       body: JSON.stringify({ id: id }),
     }
   )
-  return res.json()
+  return response.json()
 }
 
 const handleCheckoutSessionCreation = async (mode) => {


### PR DESCRIPTION
Before, when we wanted to hit the api side, we had to resort to a hack to get the url:

https://github.com/redwoodjs/example-store/blob/16060360cd04bc131cd90057aa75d55463ee4597/web/src/pages/StripeCartPage/StripeCartPage.js#L68-L69

In v0.39.3, Redwood added back `RWJS_API_URL`. Let's use it instead!