### PR TITLE
Explicitly add env var to web side

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -9,7 +9,7 @@
   title = "Redwood App"
   port = 8910
   apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  includeEnvironmentVariables = ['STRIPE_PK'] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
 [api]
   port = 8911
 [browser]


### PR DESCRIPTION
It's a best-practice to enumerate env vars used on the web side in the `includeEnvironmentVariables` key in `redwood.toml`. Here's the docs on that: https://redwoodjs.com/docs/app-configuration-redwood-toml#includeenvironmentvariables. Also we recently had an issue around not doing this: https://github.com/redwoodjs/redwood/pull/4334.