### PR TITLE
Demo checkout via GraphQL

### DIFF
--- a/api/src/functions/createCheckoutSession/createCheckoutSession.js
+++ b/api/src/functions/createCheckoutSession/createCheckoutSession.js
@@ -1,5 +1,5 @@
 import { logger } from 'src/lib/logger'
-import { stripe } from 'src/lib/stripe'
+import { createCheckoutSession } from 'src/services/checkouts'
 
 /**
  * The handler function is your code that processes http request events.
@@ -18,51 +18,11 @@ import { stripe } from 'src/lib/stripe'
  * function, and execution environment.
  */
 
-const getCartItems = {
-  subscription: [
-    {
-      price: 'price_1JdarsFnEy6nnTnpxOI5D4fA',
-      quantity: 1,
-    },
-  ],
-  payment: [
-    {
-      price_data: {
-        product_data: {
-          name: 'Bag of Apples',
-        },
-        unit_amount: 3000,
-        currency: 'zar',
-      },
-      quantity: 1,
-    },
-    {
-      price_data: {
-        product_data: {
-          name: 'Bunch of Bananas',
-        },
-        unit_amount: 2800,
-        currency: 'zar',
-      },
-      quantity: 1,
-    },
-  ],
-}
-
 export const handler = async (event, _context) => {
   logger.info('Invoked createCheckoutSession function')
   const mode = JSON.parse(event.body).mode
 
-  // Retrieve cart items from DB or wherever
-  const cartItems = getCartItems[mode]
-
-  const session = await stripe.checkout.sessions.create({
-    line_items: cartItems,
-    payment_method_types: ['card'],
-    mode: mode,
-    success_url: `http://localhost:8910/stripe-cart?success=true&sessionId={CHECKOUT_SESSION_ID}`,
-    cancel_url: `http://localhost:8910/stripe-cart?success=false`,
-  })
+  const session = await createCheckoutSession({ mode })
 
   return {
     statusCode: 200,

--- a/api/src/graphql/checkouts.sdl.js
+++ b/api/src/graphql/checkouts.sdl.js
@@ -1,0 +1,9 @@
+export const schema = gql`
+  type Session {
+    id: String!
+  }
+
+  type Mutation {
+    createCheckoutSession(mode: String!): Session! @skipAuth
+  }
+`

--- a/api/src/services/checkouts/checkouts.js
+++ b/api/src/services/checkouts/checkouts.js
@@ -1,0 +1,49 @@
+import { stripe } from 'src/lib/stripe'
+
+const getCartItems = {
+  subscription: [
+    {
+      price: 'price_1JdarsFnEy6nnTnpxOI5D4fA',
+      quantity: 1,
+    },
+  ],
+  payment: [
+    {
+      price_data: {
+        product_data: {
+          name: 'Bag of Apples',
+        },
+        unit_amount: 3000,
+        currency: 'zar',
+      },
+      quantity: 1,
+    },
+    {
+      price_data: {
+        product_data: {
+          name: 'Bunch of Bananas',
+        },
+        unit_amount: 2800,
+        currency: 'zar',
+      },
+      quantity: 1,
+    },
+  ],
+}
+
+/**
+ * @typedef {'payment' | 'subscription'} Mode
+ * @param {Mode} mode
+ */
+export const createCheckoutSession = async ({ mode }) => {
+  // Retrieve cart items from DB or wherever
+  const cartItems = getCartItems[mode]
+
+  return stripe.checkout.sessions.create({
+    line_items: cartItems,
+    payment_method_types: ['card'],
+    mode: mode,
+    success_url: `http://localhost:8910/stripe-cart?success=true&sessionId={CHECKOUT_SESSION_ID}`,
+    cancel_url: `http://localhost:8910/stripe-cart?success=false`,
+  })
+}

--- a/web/src/pages/StripeCartPage/StripeCartPage.js
+++ b/web/src/pages/StripeCartPage/StripeCartPage.js
@@ -103,6 +103,7 @@ const retrieveCheckoutSession = async (id) => {
   return response.json()
 }
 
+// eslint-disable-next-line no-unused-vars
 const handleCheckoutSessionCreation = async (mode) => {
   const stripey = await loadStripe(process.env.STRIPE_PK)
   const response = await fetch(`${window.RWJS_API_URL}/createCheckoutSession`, {

--- a/web/src/pages/StripeCartPage/StripeCartPage.js
+++ b/web/src/pages/StripeCartPage/StripeCartPage.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { useParams } from '@redwoodjs/router'
 import { useEffect, useState } from 'react'
 import { loadStripe } from '@stripe/stripe-js'
+import { useMutation } from '@redwoodjs/web'
 
 const StripeCartPage = () => {
   const [sessionData, setSessionData] = useState({})
@@ -12,9 +13,38 @@ const StripeCartPage = () => {
   // Neccesary for creating a checkout session
   const checkoutMode = 'payment'
 
-  const onCheckoutButtonClick = () => {
+  const [createCheckoutSession] = useMutation(
+    gql`
+      mutation CreateCheckoutSession($mode: String!) {
+        createCheckoutSession(mode: $mode) {
+          id
+        }
+      }
+    `,
+    {
+      variables: {
+        mode: checkoutMode,
+      },
+    }
+  )
+
+  const onCheckoutButtonClick = async () => {
     // Creates new checkout session dependent on "checkoutMode".
-    handleCheckoutSessionCreation(checkoutMode)
+    const {
+      data: {
+        createCheckoutSession: { id },
+      },
+    } = await createCheckoutSession()
+
+    const stripe = await loadStripe(process.env.STRIPE_PK)
+
+    const result = await stripe.redirectToCheckout({
+      sessionId: id,
+    })
+
+    if (result.error) {
+      console.error(result.error.message)
+    }
   }
 
   const onCustomerPortalButtonClick = () => {


### PR DESCRIPTION
@chrisvdm this is the simplest port of the `createCheckoutSession` serverless function to GraphQL I could make. I thought there'd be more boilerplate, but it's not as bad as I thought!

I'm not sure which way is quantitatively better. Maybe we could have both somehow to demonstrate Redwood's flexibility? Especially when you use the Services abstraction, switching between the two feels like it's just a matter of importing a function in a different file!