### PR TITLE
Add custom currency, url scalars

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@redwoodjs/api": "0.45.0",
     "@redwoodjs/graphql-server": "0.45.0",
+    "graphql-scalars": "1.14.1",
     "stripe": "8.203.0"
   }
 }

--- a/api/src/functions/graphql.js
+++ b/api/src/functions/graphql.js
@@ -1,5 +1,12 @@
 import { createGraphQLHandler } from '@redwoodjs/graphql-server'
 
+import {
+  CurrencyDefinition,
+  CurrencyResolver,
+  URLTypeDefinition,
+  URLResolver,
+} from 'graphql-scalars'
+
 import directives from 'src/directives/**/*.{js,ts}'
 import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
@@ -12,6 +19,14 @@ export const handler = createGraphQLHandler({
   directives,
   sdls,
   services,
+  // Custom scalars. See: https://redwoodjs.com/docs/graphql#custom-scalars.
+  schemaOptions: {
+    typeDefs: [CurrencyDefinition, URLTypeDefinition],
+    resolvers: {
+      Currency: CurrencyResolver,
+      URL: URLResolver,
+    },
+  },
   onException: () => {
     // Disconnect from your database with an unhandled exception.
     db.$disconnect()

--- a/api/src/graphql/scalars.sdl.js
+++ b/api/src/graphql/scalars.sdl.js
@@ -1,0 +1,4 @@
+export const schema = gql`
+  scalar Currency
+  scalar URL
+`

--- a/api/src/graphql/stripePrice.sdl.js
+++ b/api/src/graphql/stripePrice.sdl.js
@@ -2,7 +2,7 @@ export const schema = gql`
   type StripePrice {
     id: ID!
     active: Boolean
-    currency: String
+    currency: Currency
     nickname: String
     recurring: StripeRecurringPrice
     type: StripePriceType

--- a/api/src/graphql/stripeProduct.sdl.js
+++ b/api/src/graphql/stripeProduct.sdl.js
@@ -12,6 +12,6 @@ export const schema = gql`
     tax_code: String
     unit_label: String
     updated: String
-    url: String
+    url: URL
   }
 `


### PR DESCRIPTION
Currently, most of our fields in our SDLs are `String`s. For the most part that works, but we can take advantage of GraphQL's extendable type system by adding custom scalars to make sure these fields really are what they say they are. See https://redwoodjs.com/docs/graphql#custom-scalars.